### PR TITLE
create RPC tests for sell and buy calculations

### DIFF
--- a/test/parallel/xyk-rpc.calculate.test.ts
+++ b/test/parallel/xyk-rpc.calculate.test.ts
@@ -1,0 +1,137 @@
+import {getApi, initApi} from "../../utils/api";
+import { calculate_buy_price_rpc, calculate_sell_price_rpc, getBalanceOfPool} from '../../utils/tx'
+import {waitNewBlock} from '../../utils/eventListeners'
+import BN from 'bn.js'
+import { Keyring } from '@polkadot/api'
+import {AssetWallet, User} from "../../utils/User";
+import { Assets } from "../../utils/Assets";
+import { getEnvironmentRequiredVars } from "../../utils/utils";
+
+
+jest.spyOn(console, 'log').mockImplementation(jest.fn());
+jest.setTimeout(1500000);
+process.env.NODE_ENV = 'test';
+
+let testUser1 : User;
+
+
+let keyring : Keyring;
+let firstCurrency :BN;
+let secondCurrency :BN;
+
+// Assuming the pallet's AccountId
+const {sudo:sudoUserName} = getEnvironmentRequiredVars();
+const firstAssetAmount = 1000;
+const seccondAssetAmount = 1000;
+
+beforeAll( async () => {
+	try {
+		getApi();
+	  } catch(e) {
+		await initApi();
+	}
+	await waitNewBlock();
+	keyring = new Keyring({ type: 'sr25519' });
+
+	// setup users
+	testUser1 = new User(keyring);
+	const sudo = new User(keyring, sudoUserName);
+
+	
+	//add two curerncies and balance to testUser:
+	[firstCurrency, secondCurrency] = await Assets.setupUserWithCurrencies(testUser1, [firstAssetAmount *2 ,seccondAssetAmount *2] , sudo );
+	await testUser1.setBalance(sudo);
+	await testUser1.createPoolToAsset(new BN(firstAssetAmount), new BN(seccondAssetAmount), firstCurrency, secondCurrency);
+	
+    // add users to pair.
+	keyring.addPair(testUser1.keyRingPair);
+	keyring.addPair(sudo.keyRingPair);
+
+});
+
+beforeEach( async () => {
+	// check users accounts.
+	await waitNewBlock();
+	await testUser1.refreshAmounts(AssetWallet.BEFORE);
+})
+
+test('xyk-rpc - calculate_sell_price and calculate_buy_price matches, 1000,1000', async() => {
+
+	let poolBalanceBefore = await getBalanceOfPool(firstCurrency, secondCurrency);
+	
+	const numberOfAssets = new BN(100);
+	let sellPriceRpc = await calculate_sell_price_rpc(poolBalanceBefore[0], poolBalanceBefore[1], numberOfAssets);
+	let sellPriceRpcInverse = await calculate_sell_price_rpc(poolBalanceBefore[1], poolBalanceBefore[0], numberOfAssets);
+
+	let buyPriceRpc= await calculate_buy_price_rpc(poolBalanceBefore[0], poolBalanceBefore[1], sellPriceRpc);
+	let buyPriceRpcInverse = await calculate_buy_price_rpc(poolBalanceBefore[1], poolBalanceBefore[0], sellPriceRpc);
+
+	//in a perfect balanced pool, those number match
+	expect(sellPriceRpcInverse).toEqual(sellPriceRpc);
+	expect(buyPriceRpc).toEqual(buyPriceRpcInverse);
+
+	//the relation of buy and sell is maintained.
+	expect(buyPriceRpc).toEqual(numberOfAssets);
+	
+});
+
+test('xyk-rpc - calculate_sell_price and calculate_buy_price matches, 2000,1000', async() => {
+
+	let poolBalanceBefore = await getBalanceOfPool(firstCurrency, secondCurrency);
+	//lets unbalance it artificailly, now the relation is 2000X=1000Y
+	poolBalanceBefore[0] = poolBalanceBefore[0].add(new BN(1000));
+	
+	const numberOfAssets = new BN(100);
+	let sellPriceRpc = await calculate_sell_price_rpc(poolBalanceBefore[0], poolBalanceBefore[1], numberOfAssets);
+	let sellPriceRpcInverse = await calculate_sell_price_rpc(poolBalanceBefore[1], poolBalanceBefore[0], numberOfAssets);
+
+	let buyPriceRpc= await calculate_buy_price_rpc(poolBalanceBefore[0], poolBalanceBefore[1], sellPriceRpc);
+	let buyPriceRpcInverse = await calculate_buy_price_rpc(poolBalanceBefore[1], poolBalanceBefore[0], sellPriceRpc);
+
+	//in a not perfect balanced pool, those number can not match
+	expect(sellPriceRpcInverse).not.toEqual(sellPriceRpc);
+	expect(buyPriceRpc).not.toEqual(buyPriceRpcInverse);
+
+	//the relation of buy and sell is maintained.
+	//because of rounding, we need to expend one unit more
+	expect(buyPriceRpc.add(new BN(1))).toEqual(numberOfAssets);
+	
+});
+
+test('xyk-rpc - calculate_sell_price matches with the real sell', async() => {
+
+	let poolBalanceBefore = await getBalanceOfPool(firstCurrency, secondCurrency);
+	
+	const numberOfAssets = new BN(100);
+	let sellPriceRpc = await calculate_sell_price_rpc(poolBalanceBefore[0], poolBalanceBefore[1], numberOfAssets);
+	await testUser1.sellAssets(firstCurrency, secondCurrency , numberOfAssets);
+	await testUser1.refreshAmounts(AssetWallet.AFTER);
+	const assetsSold = testUser1.getAsset(firstCurrency)?.amountAfter;
+	const assetsBought = testUser1.getAsset(secondCurrency)?.amountAfter;
+
+	//the relation of buy and sell is maintained.
+	//because of rounding, we need to expend one unit more
+	expect(assetsSold).toEqual(testUser1.getAsset(firstCurrency)?.amountBefore.sub(numberOfAssets));
+	expect(assetsBought).toEqual(testUser1.getAsset(secondCurrency)?.amountBefore.add(sellPriceRpc));
+	
+});
+
+test('xyk-rpc - calculate_buy_price matches with the real buy', async() => {
+
+	let poolBalanceBefore = await getBalanceOfPool(firstCurrency, secondCurrency);
+	
+	const numberOfAssets = new BN(100);
+	let sellPriceRpc = await calculate_buy_price_rpc(poolBalanceBefore[0], poolBalanceBefore[1], numberOfAssets);
+	await testUser1.buyAssets(firstCurrency, secondCurrency , numberOfAssets);
+	await testUser1.refreshAmounts(AssetWallet.AFTER);
+	const assetsSold = testUser1.getAsset(firstCurrency)?.amountAfter;
+	const assetsBought = testUser1.getAsset(secondCurrency)?.amountAfter;
+
+	//the relation of buy and sell is maintained.
+	//because of rounding, we need to expend one unit more
+	expect(assetsSold).toEqual(testUser1.getAsset(firstCurrency)?.amountBefore.sub(sellPriceRpc));
+	expect(assetsBought).toEqual(testUser1.getAsset(secondCurrency)?.amountBefore.add(numberOfAssets));
+	
+});
+
+

--- a/test/parallel/xyk-rpc.calculate.test.ts
+++ b/test/parallel/xyk-rpc.calculate.test.ts
@@ -109,8 +109,6 @@ test('xyk-rpc - calculate_sell_price matches with the real sell', async() => {
 	const assetsSold = testUser1.getAsset(firstCurrency)?.amountAfter;
 	const assetsBought = testUser1.getAsset(secondCurrency)?.amountAfter;
 
-	//the relation of buy and sell is maintained.
-	//because of rounding, we need to expend one unit more
 	expect(assetsSold).toEqual(testUser1.getAsset(firstCurrency)?.amountBefore.sub(numberOfAssets));
 	expect(assetsBought).toEqual(testUser1.getAsset(secondCurrency)?.amountBefore.add(sellPriceRpc));
 	
@@ -127,8 +125,6 @@ test('xyk-rpc - calculate_buy_price matches with the real buy', async() => {
 	const assetsSold = testUser1.getAsset(firstCurrency)?.amountAfter;
 	const assetsBought = testUser1.getAsset(secondCurrency)?.amountAfter;
 
-	//the relation of buy and sell is maintained.
-	//because of rounding, we need to expend one unit more
 	expect(assetsSold).toEqual(testUser1.getAsset(firstCurrency)?.amountBefore.sub(sellPriceRpc));
 	expect(assetsBought).toEqual(testUser1.getAsset(secondCurrency)?.amountBefore.add(numberOfAssets));
 	

--- a/test/parallel/xyk-rpc.error.test.ts
+++ b/test/parallel/xyk-rpc.error.test.ts
@@ -1,0 +1,66 @@
+import {getApi, initApi} from "../../utils/api";
+import { calculate_buy_price_rpc, calculate_sell_price_rpc} from '../../utils/tx'
+import BN from 'bn.js'
+
+
+jest.spyOn(console, 'log').mockImplementation(jest.fn());
+jest.setTimeout(1500000);
+process.env.NODE_ENV = 'test';
+
+beforeAll( async () => {
+	try {
+		getApi();
+	  } catch(e) {
+		await initApi();
+	}
+
+})
+
+
+test.each([
+		[new BN(-1),new BN(-1),new BN(-1),"createType(Balance):: Balance: Negative number passed to unsigned type"],
+		[new BN(1),new BN(-1),new BN(1),"createType(Balance):: Balance: Negative number passed to unsigned type"],
+		[new BN(-1),new BN(1),new BN(1),"createType(Balance):: Balance: Negative number passed to unsigned type"],
+	])
+	('xyk-rpc - calculate_sell_price validates parameters - Negative params', async(input_reserve,output_reserve,amount, expected) => {
+
+	await expect( 
+		calculate_sell_price_rpc(input_reserve,output_reserve, amount)
+	).rejects
+	.toThrow(expected.toString())
+
+	await expect( 
+		calculate_buy_price_rpc(input_reserve,output_reserve, amount)
+	).rejects
+	.toThrow(expected.toString())
+	
+});
+
+test.each([
+	[new BN(1),new BN(1),new BN(0),new BN(0)],
+	[new BN(0),new BN(0),new BN(0),new BN(0)],
+	[new BN(0),new BN(1),new BN(1),new BN(1)],
+	[new BN(0),new BN(0),new BN(1),new BN(0)],
+])
+('xyk-rpc - calculate_sell_price validates parameters - Zeroes [inputReserve->%s,outputReserve->%s,amount->%s,expected->%s]', async(input_reserve,output_reserve,amount, expected) => {
+
+	const priceSell = await calculate_sell_price_rpc(input_reserve,output_reserve, amount);
+	expect(priceSell).toEqual(expected);
+
+});
+
+test.each([
+	[new BN(1),new BN(1),new BN(0),new BN(1)], //imput_reserve = 1 (buying 0 it cost 1)? ¡¡ weird !!
+	[new BN(0),new BN(0),new BN(0),new BN(0)], // al zeroes is = 0
+	[new BN(0),new BN(1),new BN(1),new BN(0)], //imput_reserve = 0 (it must cost 0) 
+	[new BN(0),new BN(0),new BN(1),new BN(0)], //imput_reserve = 0 (buying 1 of nothing it must cost 0) 
+	[new BN(1),new BN(0),new BN(0),new BN(0)], //imput_reserve = 1 (buying 0 it must cost 0) 
+])
+('xyk-rpc - calculate_buy_price validates parameters - Zeroes [inputReserve->%s,outputReserve->%s,amount->%s,expected->%s]', async(input_reserve,output_reserve,amount, expected) => {
+
+	const priceSell = await calculate_buy_price_rpc(input_reserve,output_reserve, amount);
+	expect(priceSell).toEqual(expected);
+
+});
+
+

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -15,7 +15,7 @@ export const initApi = async (uri = '') => {
   // const wsProvider = new WsProvider(process.env.API_URL || 'ws://mangata-node:9944')
   if(!uri)
     uri = envUri;
-  
+  console.info(`TEST_INFO: Running test in ${uri}`);
   const wsProvider = new WsProvider(uri)
   api = await ApiPromise.create({
     provider: wsProvider,
@@ -78,6 +78,10 @@ export const initApi = async (uri = '') => {
       },
     },
     types: {
+      SeedType: {
+        seed: "[u8;32]",
+        proof: "[u8;64]"
+      },
       CurrencyIdOf: "u32",
       CurrencyId: "u32",
       Balance: 'u128',


### PR DESCRIPTION
Create buy/sell calculations that checks:

- Zero and negative values and validation handling
- Two accuracy tests
- Test that ensures that the amount calculated is the real amount resturned after buy/sell