### PR TITLE
Add a dev container to mangata-e2e

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,9 @@ RUN su node -c "npm install -g jest"
 # Export variables
 ENV TEST_PALLET_ADDRESS='5EYCAe5XGPRojsCSi9p1ZZQ5qgeJGFcTxPxrsFRzkASu6bT2'
 ENV TEST_SUDO_NAME='//Maciatko'
-ENV API_URL='ws://127.0.0.1:9944'
+ENV API_URL='ws://node_alice:9944'
 ENV TEST_USER_NAME='//Alice'
 ENV LOG_INFO='info'
 ENV UI_URL='https://staging.mangata.finance/'
+ENV MNEMONIC_POLK='dismiss addict reduce fitness install aisle creek they seek palace stereo trumpet' 
+ENV MNEMONIC_META='escape quiz cereal ribbon eagle appear replace hub inside raccoon control addict'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,8 +20,8 @@ RUN su node -c "npm install -g jest"
 
 # Export variables
 ENV TEST_PALLET_ADDRESS='5EYCAe5XGPRojsCSi9p1ZZQ5qgeJGFcTxPxrsFRzkASu6bT2'
-ENV TEST_SUDO_NAME='//node'
-ENV API_URL='wss://staging.testnode.mangata.finance:9945'
+ENV TEST_SUDO_NAME='//Maciatko'
+ENV API_URL='ws://127.0.0.1:9944'
 ENV TEST_USER_NAME='//Alice'
 ENV LOG_INFO='info'
 ENV UI_URL='https://staging.mangata.finance/'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2
     && make install 
 
 # Global npm modules
-RUN su node -c "npm install -g jest"
+RUN su node -c "npm install -g jest jest-allure"
 
 # Export variables
 ENV TEST_PALLET_ADDRESS='5EYCAe5XGPRojsCSi9p1ZZQ5qgeJGFcTxPxrsFRzkASu6bT2'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# System dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        build-essential \
+        libssl-dev
+    
+# Install cmake for xoshiro
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz \
+    && tar -zxvf cmake-3.20.2.tar.gz \
+    && cd cmake-3.20.2 \
+    && ./bootstrap \
+    && make \
+    && make install 
+
+# Global npm modules
+RUN su node -c "npm install -g jest"
+
+# Export variables
+ENV TEST_PALLET_ADDRESS='5EYCAe5XGPRojsCSi9p1ZZQ5qgeJGFcTxPxrsFRzkASu6bT2'
+ENV TEST_SUDO_NAME='//node'
+ENV API_URL='wss://staging.testnode.mangata.finance:9945'
+ENV TEST_USER_NAME='//Alice'
+ENV LOG_INFO='info'
+ENV UI_URL='https://staging.mangata.finance/'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": { 
+			"VARIANT": "16"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 12, 14, 16
 		"args": { 
-			"VARIANT": "16"
+			"VARIANT": "14"
 		}
 	},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,23 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/typescript-node
 {
-	"name": "Node.js & TypeScript",
+	"name": "Mangata E2E Dev Env",
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 12, 14, 16
 		"args": { 
-			"VARIANT": "14"
+			"VARIANT": "16"
 		},
 	},
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {},
 
-
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "yarn",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 
 	"runArgs": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		// Update 'VARIANT' to pick a Node version: 12, 14, 16
 		"args": { 
 			"VARIANT": "14"
-		}
+		},
 	},
 
 	// Set *default* container specific settings.json values on container create.
@@ -23,8 +23,12 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	"postCreateCommand": "yarn",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+	"remoteUser": "node",
+
+	"runArgs": [
+		"--network=dockerfiles_testing_net_automation",
+	]
 }

--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Basically all system and project dependencies should be added to `.devcontainer/
 So somehow we now have essentially a distributed system for developing and that brings its own problems. If you get stuck, tear down chain running in docker-compose, spin it back up, and rebuild the devcontainer. 
 1. Close vscode
 2. `docker-compose -f devops/dockerfiles/docker-compose.yml down`
-3. `docker-compose -f devops/dockerfiles/docker-compose.yml down`
+3. `docker-compose -f devops/dockerfiles/docker-compose.yml up`
 4. Re-open vscode
 5. `ctrl+shift+p` and search for _Remote-Containers: Rebuild and Reopen in Container_
 ---

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,23 @@ This project has been created to test individual and combined API functionalitie
 2. Clone the code
 3. Run `yarn` in the root folder.
 4. Install Jest test framework globally. `yarn global add  jest -g `
+
+### Setup with Dev Container
+1. Install `docker`, `docker-compose`, and `vscode`
+2. Install the `ms-vscode-remote.remote-containers` vscode extension
+3. Run `docker-compose -f devops/dockerfiles/docker-compose.yml up` in a seperate terminal
+4. Open the repo in vscode and click 'Reopen in container' or `ctrl+shift+p` and search for _Remote-Containers: Open Folder in Container_
+
+#### Working with Dev Containers
+Basically all system and project dependencies should be added to `.devcontainer/Dockerfile` so all developer dependencies are tracked in version control and available to anyone. 
+
+#### Troubleshooting
+So somehow we now have essentially a distributed system for developing and that brings its own problems. If you get stuck, tear down chain running in docker-compose, spin it back up, and rebuild the devcontainer. 
+1. Close vscode
+2. `docker-compose -f devops/dockerfiles/docker-compose.yml down`
+3. `docker-compose -f devops/dockerfiles/docker-compose.yml down`
+4. Re-open vscode
+5. `ctrl+shift+p` and search for _Remote-Containers: Rebuild and Reopen in Container_
 ---
 ###  How to build
 1. `npm run build`

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -191,6 +191,10 @@ export const initApi = async (uri = '') => {
       BalanceLock: {
         id: "[u8; 8]",
         amount: 'Balance'
+      },
+      Valuation: {
+        liquidity_token_amount: 'Balance',
+        mng_valuation: 'Balance'
       }
     },
   })


### PR DESCRIPTION
These files allow you to use a docker environment to manage system and project dependencies. Requirements to use this are `Docker`, `docker-compose`, and `ms-vscode-remote.remote-containers`. When you open the repo a pop-up will ask if you want to run within the container. Note: we need to manually build `cmake` to install `xoshiro` (a psudorandom number library for JS) which takes some time to build the first time but does cache. 

Further caveat, you need to have ran `docker-compose -f devops/dockerfiles/docker-compose.yml up` in advance to have the network set-up for the devcontainer to work too. This can be improved by using docker-compose to run both at the same time in the future. 