### PR TITLE
Create symmetry for pool functionalities

### DIFF
--- a/test/parallel/xyk-pallet.API.pool.test.ts
+++ b/test/parallel/xyk-pallet.API.pool.test.ts
@@ -35,6 +35,7 @@ import {
 } from "../../utils/utils";
 import { getEventResultFromTxWait } from "../../utils/txHandler";
 import { testLog } from "../../utils/Logger";
+import { hexToBn } from "@polkadot/util";
 
 jest.spyOn(console, "log").mockImplementation(jest.fn());
 jest.setTimeout(1500000);
@@ -451,9 +452,25 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
     });
   });
   test("GetBalance x-y and y-x pool", async () => {
-    const poolAssetsXY = await getBalanceOfPool(firstCurrency, secondCurrency);
-    const poolAssetsYX = await getBalanceOfPool(secondCurrency, firstCurrency);
-    expect(poolAssetsXY).collectionBnEqual(poolAssetsYX);
+    const api = await getApi();
+    const poolAssetsXY = await api.query.xyk.pools([
+      firstCurrency,
+      secondCurrency,
+    ]);
+    const assetValueXY = [
+      hexToBn(JSON.parse(poolAssetsXY.toString())[0]),
+      hexToBn(JSON.parse(poolAssetsXY.toString())[1]),
+    ];
+    const poolAssetsYX = await api.query.xyk.pools([
+      secondCurrency,
+      firstCurrency,
+    ]);
+    const assetValueYX = [
+      hexToBn(JSON.parse(poolAssetsYX.toString())[0]),
+      hexToBn(JSON.parse(poolAssetsYX.toString())[1]),
+    ];
+
+    expect(assetValueXY).collectionBnEqual(assetValueYX);
   });
   test("Minting x-y and y-x pool", async () => {
     await testUser1.mintLiquidity(firstCurrency, secondCurrency, new BN(100));
@@ -487,3 +504,4 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
     expect(liqXY).bnEqual(liqYX);
   });
 });
+

--- a/test/parallel/xyk-pallet.API.pool.test.ts
+++ b/test/parallel/xyk-pallet.API.pool.test.ts
@@ -504,4 +504,3 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
     expect(liqXY).bnEqual(liqYX);
   });
 });
-

--- a/test/parallel/xyk-pallet.API.pool.test.ts
+++ b/test/parallel/xyk-pallet.API.pool.test.ts
@@ -519,7 +519,10 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
       hexToBn(JSON.parse(poolAssetsYX.toString())[1]),
     ];
 
-    expect(assetValueXY).collectionBnEqual(assetValueYX);
+    expect(assetValueXY).not.collectionBnEqual(assetValueYX);
+    const poolValuesXY = await getBalanceOfPool(secondCurrency, firstCurrency);
+    const poolValuesYX = await getBalanceOfPool(firstCurrency, secondCurrency);
+    expect(poolValuesXY).collectionBnEqual(poolValuesYX);
   });
   test("Minting x-y and y-x pool", async () => {
     await testUser1.mintLiquidity(firstCurrency, secondCurrency, new BN(100));
@@ -540,6 +543,17 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
     );
   });
   test("GetLiquidityAssetID x-y and y-x pool", async () => {
+    const api = getApi();
+    const liqXYK = await api.query.xyk.liquidityAssets([
+      firstCurrency,
+      secondCurrency,
+    ]);
+    const liqYXK = await api.query.xyk.liquidityAssets([
+      secondCurrency,
+      firstCurrency,
+    ]);
+    expect(new BN(liqXYK.toString())).not.bnEqual(new BN(liqYXK.toString()));
+
     const liqXY = await getLiquidityAssetId(firstCurrency, secondCurrency);
     const liqYX = await getLiquidityAssetId(secondCurrency, firstCurrency);
     const pool = await getLiquidityPool(liqYX);
@@ -549,7 +563,6 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
     expect(
       pool.some((x) => x.toString() === secondCurrency.toString())
     ).toBeTruthy();
-
     expect(liqXY).bnEqual(liqYX);
   });
 });

--- a/test/parallel/xyk-pallet.API.pool.test.ts
+++ b/test/parallel/xyk-pallet.API.pool.test.ts
@@ -460,7 +460,7 @@ describe("xyk-pallet - Pool opeations: Simmetry", () => {
 
     sudo = new User(keyring, sudoUserName);
 
-    //add two curerncies and balance to testUser:
+    //add two currencies and balance to testUser:
     [firstCurrency, secondCurrency] = await Assets.setupUserWithCurrencies(
       testUser1,
       [defaultCurrecyValue, defaultCurrecyValue.add(new BN(1))],

--- a/utils/tx.ts
+++ b/utils/tx.ts
@@ -265,12 +265,15 @@ export async function getBalanceOfPool(
 export async function getLiquidityAssetId(assetId1: BN, assetId2: BN) {
   const api = getApi();
 
-  const liquidity_asset_id = await api.query.xyk.liquidityAssets([
+  let liquidity_asset_id = await api.query.xyk.liquidityAssets([
     assetId1,
     assetId2,
   ]);
   if (liquidity_asset_id.isEmpty) {
-    return new BN(-1);
+    liquidity_asset_id = await api.query.xyk.liquidityAssets([
+      assetId2,
+      assetId1,
+    ]);
   }
   return new BN(liquidity_asset_id.toString());
 }


### PR DESCRIPTION
  xyk-pallet - Pool opeations: Simmetry
    ✕ GetBalance x-y and y-x pool (3534 ms)
    ✓ Minting x-y and y-x pool (32722 ms)
    ✓ Burning x-y and y-x pool (36122 ms)
    ✕ GetLiquidityAssetID x-y and y-x pool (15 ms)

@Stano, I can only see that GetLiquidityAssetId and pool symmetry is not fulfilled. Maybe we can meet with @gleb-urvanov  about what todo next.


UPDATE: 
After the discussion, it was accepted the symmetry won't be accomplished and SDK will do.
Adding into the tests that the symmetry is NOT for the GetBalance and GetLiquidityAssetId and later SKD replacement will do the job,
ready to be reviewed!
