### PR TITLE
Add shell.nix for nodejs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+    name = "node";
+    buildInputs = [
+        nodejs
+        yarn
+    ];
+    shellHook = ''
+        export PATH="$PWD/node_modules/.bin/:$PATH"
+        export TEST_SUDO_NAME=//Maciatko 
+        export TEST_PALLET_ADDRESS=5EYCAe5XGPRojsCSi9p1ZZQ5qgeJGFcTxPxrsFRzkASu6bT2 
+        export E2E_XYK_PALLET_ADDRESS=5EYCAe5XGPRojsCSi9p1ZZQ5qgeJGFcTxPxrsFRzkASu6bT2 
+        export E2E_TREASURY_PALLET_ADDRESS=5EYCAe5ijiYfyeZ2JJCGq56LmPyNRAKzpG4QkoQkkQNB5e6Z 
+        export E2E_TREASURY_BURN_PALLET_ADDRESS=5EYCAe5ijiYfyeZ2JJezKNMZfdbiFMyQc4YVzxaiMebAZBcm 
+        export API_URL=ws://127.0.0.1:9944  
+    '';
+}


### PR DESCRIPTION
Steps to run: 

1. Install nix `curl -L https://nixos.org/nix/install | sh`
2. Run `nix-shell shell.nix` in the root of this repo
3. Test by running `yarn`

Confirmed this works on Apple Silicon. 