### PR TITLE
E2E FE update chrome to 110 and fix workflows

### DIFF
--- a/.github/workflows/microapps-ui-test.yml
+++ b/.github/workflows/microapps-ui-test.yml
@@ -18,8 +18,6 @@ on:
           default: ''
       # For manual triggering
  
-  repository_dispatch:
-    types: [run-ci]
 jobs:
 
   test:
@@ -64,7 +62,7 @@ jobs:
         uses: Xotabu4/selenoid-github-action@v2
         with:
           selenoid-start-arguments: |
-            --args "-timeout 300s" --browsers 'chrome:95.0;chrome:96.0;chrome:94.0'
+            --args "-timeout 300s" --browsers 'chrome:108.0;chrome:109.0;chrome:110.0'
         
 
       - name: Set Configuration - Integration

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -93,7 +93,7 @@ jobs:
         uses: Xotabu4/selenoid-github-action@v2
         with:
           selenoid-start-arguments: |
-            --args "-timeout 300s" --browsers 'chrome:95.0;chrome:96.0;chrome:94.0'
+            --args "-timeout 300s" --browsers 'chrome:108.0;chrome:109.0;chrome:110.0'
         
 
       - name: Set Configuration - Integration

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "bs58": "^4.0.1",
-    "chromedriver": "^108.0.0",
+    "chromedriver": "^110.0.0",
     "dotenv": "^16.0.1",
     "eslint": "7.26.0",
     "ethers": "^5.4.7",

--- a/utils/frontend/utils/Driver.ts
+++ b/utils/frontend/utils/Driver.ts
@@ -24,7 +24,7 @@ export const DriverBuilder = (function () {
 
     let caps: Capabilities = new Capabilities();
     caps = Capabilities.chrome();
-    caps.set("version", "94.0");
+    caps.set("version", "110.0");
     caps.set("selenoid:options", { enableVNC: true, enableVideo: true });
 
     driver = new Builder()


### PR DESCRIPTION
- Update chrome used in tests to 110
- Update Selenoid environments to include said chrome version
- remove incorrect repository dispatch from microapps workflow