### PR TITLE
Fix dex ui tests

### DIFF
--- a/test/ui/ui-main.deposit.test.ts
+++ b/test/ui/ui-main.deposit.test.ts
@@ -139,7 +139,7 @@ describe("UI deposit modal tests - no action", () => {
       await depositModal.areTokenListElementsVisible(KSM_ASSET_NAME);
     expect(areTokenListElementsVisible).toBeTruthy();
     await depositModal.selectToken(KSM_ASSET_NAME);
-    await depositModal.enterValue("0.001");
+    await depositModal.enterValue("0.000001");
     await depositModal.waitForProgressBar();
 
     await depositModal.waitForContinueState(false);

--- a/utils/frontend/pages/DepositModal.ts
+++ b/utils/frontend/pages/DepositModal.ts
@@ -59,7 +59,7 @@ export class DepositModal {
 
   async areTokenListElementsVisible(
     assetName: string,
-    retries = 5
+    retries = 10
   ): Promise<boolean> {
     try {
       const assetTestId = `TokensModal-token-${assetName}`;


### PR DESCRIPTION
Changing deposit case so that it matches new behavior:
- we can now deposit 0.001 KSM as long as its higher than fee