### PR TITLE
Microapps withdraw tests

### DIFF
--- a/test/microapps-ui-xcm/microapps-ui-main.withdraw.test.ts
+++ b/test/microapps-ui-xcm/microapps-ui-main.withdraw.test.ts
@@ -30,7 +30,11 @@ import { devTestingPairs } from "../../utils/setup";
 import { AssetId } from "../../utils/ChainSpecs";
 import { BN_THOUSAND } from "@mangata-finance/sdk";
 import StashServiceMockSingleton from "../../utils/stashServiceMockSingleton";
-import { ModalType, NotificationModal, TransactionType } from "../../utils/frontend/microapps-pages/NotificationModal";
+import {
+  ModalType,
+  NotificationModal,
+  TransactionType,
+} from "../../utils/frontend/microapps-pages/NotificationModal";
 import { WithdrawModal } from "../../utils/frontend/microapps-pages/WithdrawModal";
 
 jest.spyOn(console, "log").mockImplementation(jest.fn());
@@ -144,7 +148,11 @@ describe("Microapps UI withdraw modal tests", () => {
     await withdrawModal.clickContinue();
 
     const modal = new NotificationModal(driver);
-    await modal.waitForModalState(ModalType.Confirm, TransactionType.Withdraw, 3000);
+    await modal.waitForModalState(
+      ModalType.Confirm,
+      TransactionType.Withdraw,
+      3000
+    );
     const isModalWaitingForSignVisible = await modal.isModalVisible(
       ModalType.Confirm,
       TransactionType.Withdraw

--- a/utils/frontend/microapps-pages/WalletWrapper.ts
+++ b/utils/frontend/microapps-pages/WalletWrapper.ts
@@ -45,6 +45,11 @@ export class WalletWrapper {
     await clickElement(this.driver, betaButton);
   }
 
+  async openWithdraw() {
+    const betaButton = buildXpathByElementText("button", "Withdraw");
+    await clickElement(this.driver, betaButton);
+  }
+
   async isWalletConnected() {
     const walletWrapper = buildDataTestIdXpath(DIV_WALLET_WRAPPER);
     const walletConnectedContent = buildDataTestIdXpath(DIV_WALLET_CONNECTED);

--- a/utils/frontend/microapps-pages/WithdrawModal.ts
+++ b/utils/frontend/microapps-pages/WithdrawModal.ts
@@ -1,0 +1,133 @@
+import { By, WebDriver } from "selenium-webdriver";
+import { sleep } from "../../utils";
+import {
+  buildDataTestIdXpath,
+  buildXpathByText,
+  clickElement,
+  getText,
+  isDisplayed,
+  waitForElementStateInterval,
+  waitForElementVisible,
+  writeText,
+} from "../utils/Helper";
+
+//SELECTORS
+const WITHDRAW_MODAL_CONTENT = "withdrawal-modal-content";
+const BTN_CHAIN_SELECT = "chain-select-btn";
+const CHAIN_SELECT_LIST = "chain-select-list";
+const BTN_SELECT_TOKEN = "tokenInput-selector-btn";
+const TOKEN_LIST = "tokenList";
+const TOKEN_LIST_ITEM = "tokenList-item";
+const TOKEN_TEXT_INPUT = "tokenInput-input";
+const BTN_SUBMIT = "submit-withdrawal-button";
+const ORIGIN_FEE = "origin-fee";
+const DESTINATION_FEE = "destination-fee";
+const FEE_VALUE = "fee-value";
+const ERR_MESSAGE = "deposit-error-message";
+
+export class WithdrawModal {
+  driver: WebDriver;
+
+  constructor(driver: WebDriver) {
+    this.driver = driver;
+  }
+
+  async isModalVisible() {
+    const title = buildDataTestIdXpath(WITHDRAW_MODAL_CONTENT);
+    return isDisplayed(this.driver, title);
+  }
+
+  async isOriginFeeDisplayed() {
+    const xpath =
+      buildDataTestIdXpath(ORIGIN_FEE) + buildDataTestIdXpath(FEE_VALUE);
+    return isDisplayed(this.driver, xpath);
+  }
+
+  async isDestinationFeeDisplayed() {
+    const xpath =
+      buildDataTestIdXpath(DESTINATION_FEE) + buildDataTestIdXpath(FEE_VALUE);
+    return isDisplayed(this.driver, xpath);
+  }
+
+  async openChainList() {
+    await clickElement(this.driver, buildDataTestIdXpath(BTN_CHAIN_SELECT));
+  }
+
+  async isErrorMessage() {
+    const errMessageXpath = buildDataTestIdXpath(ERR_MESSAGE);
+    const isAlert = await isDisplayed(this.driver, errMessageXpath);
+    return isAlert;
+  }
+
+  async selectChain(chainName: string) {
+    await waitForElementVisible(
+      this.driver,
+      buildDataTestIdXpath(CHAIN_SELECT_LIST),
+      5000
+    );
+    const chainTestId = `${chainName}-chain`;
+    const chainLocator = buildDataTestIdXpath(chainTestId);
+    await sleep(1000);
+    await waitForElementVisible(this.driver, chainLocator, 5000);
+    await clickElement(this.driver, chainLocator);
+  }
+
+  async openTokensList() {
+    await clickElement(this.driver, buildDataTestIdXpath(BTN_SELECT_TOKEN));
+  }
+
+  async selectToken(assetName: string) {
+    //const tokenTestId = `tokenList-item`;
+    const tokenLocator =
+      buildDataTestIdXpath(TOKEN_LIST_ITEM) + buildXpathByText(assetName);
+    await sleep(1000);
+    await waitForElementVisible(this.driver, tokenLocator, 5000);
+    await clickElement(this.driver, tokenLocator);
+  }
+
+  async getTokenAmount(assetName: string) {
+    const assetTestId = `token-list-token-${assetName}-balance`;
+    const assetLocator = buildDataTestIdXpath(assetTestId);
+    return parseFloat(await getText(this.driver, assetLocator));
+  }
+
+  async waitForTokenListElementsVisible(assetName: string) {
+    await waitForElementVisible(
+      this.driver,
+      buildDataTestIdXpath(TOKEN_LIST),
+      5000
+    );
+    const tokenTestId = `token-icon-${assetName}`;
+    const tokenLocator = buildDataTestIdXpath(tokenTestId);
+    await waitForElementVisible(this.driver, tokenLocator, 5000);
+  }
+
+  async enterValue(amount: string) {
+    const inputTokenLocator = buildDataTestIdXpath(TOKEN_TEXT_INPUT);
+    await clickElement(this.driver, inputTokenLocator);
+    await writeText(this.driver, inputTokenLocator, amount);
+  }
+
+  async waitForContinueState(isEnabled: boolean, timeout: number) {
+    const continueBtn = buildDataTestIdXpath(BTN_SUBMIT);
+    await waitForElementStateInterval(
+      this.driver,
+      continueBtn,
+      isEnabled,
+      timeout
+    );
+  }
+
+  async clickContinue() {
+    const continueBtn = buildDataTestIdXpath(BTN_SUBMIT);
+    await clickElement(this.driver, continueBtn);
+  }
+
+  async isContinueButtonEnabled() {
+    const xpath = buildDataTestIdXpath(BTN_SUBMIT);
+    const enabled = await (
+      await this.driver.findElement(By.xpath(xpath))
+    ).isEnabled();
+    return enabled;
+  }
+}


### PR DESCRIPTION
Adding tests for withdrawal flow:
- Withdraw process with notifications
- Input values, 0 values
- Withdraw modal errors

Next steps will be adding tests for each token and splitting tests into workers as parallel run. Here is successful execution:
<img width="716" alt="Screenshot 2023-08-30 at 12 52 43" src="https://github.com/mangata-finance/mangata-e2e/assets/112616777/6e1d1ff9-a07a-4fb4-8fe9-c4639ab4d36e">
