### PR TITLE
E2E stopping leftover tests for old app

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -9,7 +9,7 @@ on:
           required: false
           default: ''
  
-  repository_dispatch:
+#  repository_dispatch:
 # GonCer: Decommission old app    types: [run-ci]
 jobs:
 


### PR DESCRIPTION
repository_dispatch event without specifying the types, will listen for all repository_dispatch events, regardless of the event types. Commented it too.