### PR TITLE
Fix for metamask extension load

### DIFF
--- a/utils/frontend/utils/Driver.ts
+++ b/utils/frontend/utils/Driver.ts
@@ -44,8 +44,20 @@ export const DriverBuilder = (function () {
       .build();
     await driver!.manage().setTimeouts({ script: 5000 });
     await driver!.manage().window().maximize();
+    await waitForMultipleTabs(driver);
 
     return driver;
+  }
+
+  async function waitForMultipleTabs(driver: WebDriver) {
+    await driver.wait(
+      async () => {
+        const handles = await driver.getAllWindowHandles();
+        return handles.length > 2;
+      },
+      10000,
+      "Waiting for all extensions tabs to open",
+    );
   }
 
   let driver: WebDriver | undefined;

--- a/utils/frontend/utils/Driver.ts
+++ b/utils/frontend/utils/Driver.ts
@@ -44,7 +44,9 @@ export const DriverBuilder = (function () {
       .build();
     await driver!.manage().setTimeouts({ script: 5000 });
     await driver!.manage().window().maximize();
-    await waitForMultipleTabs(driver);
+    if (addExtensions) {
+      await waitForMultipleTabs(driver);
+    }
 
     return driver;
   }


### PR DESCRIPTION
We are loading 3 extensions now and metamask tab opening is somewhat delayed, that causes flakiness in tests because Driver proceeds to close tabs and opening app without waiting for all extensions to load. This PR adds required wait.