### PR TITLE
add http call waiter for flaky tests

### DIFF
--- a/test/microapps-prod/microapps-prod-main.pools.test.ts
+++ b/test/microapps-prod/microapps-prod-main.pools.test.ts
@@ -15,6 +15,7 @@ import {
   addExtraLogs,
   comparePoolsLists,
   importPolkadotExtension,
+  waitForHttpCall,
 } from "../../utils/frontend/utils/Helper";
 import {
   DUMMY_POOL_ASSET_ID,
@@ -83,6 +84,8 @@ describe("Microapps UI liq pools tests", () => {
 
     const sidebar = new Sidebar(driver);
     await sidebar.clickNavLiqPools();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
     const liquidityPools = await new LiqPools(driver);
     const fePoolsList = await liquidityPools.getPoolsList();
     await comparePoolsLists(fePoolsList, promotedPoolsInfo, liquidityPools);
@@ -114,6 +117,8 @@ describe("Microapps UI liq pools tests", () => {
 
     const sidebar = new Sidebar(driver);
     await sidebar.clickNavLiqPools();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
     const liquidityPools = await new LiqPools(driver);
     await liquidityPools.clickAllPoolsTab();
     const fePoolsList = await liquidityPools.getPoolsList();

--- a/test/microapps-prod/microapps-prod-main.wallet.test.ts
+++ b/test/microapps-prod/microapps-prod-main.wallet.test.ts
@@ -68,8 +68,6 @@ describe("Microapps Prod UI wallet tests", () => {
 
     const walletWrapper = new WalletWrapper(driver);
     await walletWrapper.openWalletConnectionInfo();
-    const isKSM = await walletWrapper.isMyTokensRowDisplayed(KSM_ASSET_NAME);
-    expect(isKSM).toBeFalsy();
     const isMGX = await walletWrapper.isMyTokensRowDisplayed(MGX_ASSET_NAME);
     expect(isMGX).toBeTruthy();
     const isTUR = await walletWrapper.isMyTokensRowDisplayed(TUR_ASSET_NAME);

--- a/test/microapps-prod/microapps-prod-main.wallet.test.ts
+++ b/test/microapps-prod/microapps-prod-main.wallet.test.ts
@@ -30,7 +30,6 @@ let driver: WebDriver;
 let testUser1: User;
 
 const acc_name = "acc_automation";
-const KSM_ASSET_NAME = "KSM";
 const MGX_ASSET_NAME = "MGX";
 const TUR_ASSET_NAME = "TUR";
 

--- a/test/microapps-ui-xcm/microapps-ui-main.accounts.test.ts
+++ b/test/microapps-ui-xcm/microapps-ui-main.accounts.test.ts
@@ -153,7 +153,11 @@ describe.each`
       await setupPageWithState(driver, accountName);
       const sidebar = new Sidebar(driver);
       await sidebar.clickNavLiqPools();
-      const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+      const status = await waitForHttpCall(
+        driver,
+        "token/order-buckets",
+        20000,
+      );
       expect(status).toEqual(200);
 
       const poolsList = new LiqPools(driver);

--- a/test/microapps-ui-xcm/microapps-ui-main.accounts.test.ts
+++ b/test/microapps-ui-xcm/microapps-ui-main.accounts.test.ts
@@ -10,6 +10,7 @@ import { DriverBuilder } from "../../utils/frontend/utils/Driver";
 import {
   addExtraLogs,
   importPolkadotExtension,
+  waitForHttpCall,
 } from "../../utils/frontend/utils/Helper";
 import { getEnvironmentRequiredVars } from "../../utils/utils";
 import { Node } from "../../utils/Framework/Node/Node";
@@ -152,6 +153,8 @@ describe.each`
       await setupPageWithState(driver, accountName);
       const sidebar = new Sidebar(driver);
       await sidebar.clickNavLiqPools();
+      const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+      expect(status).toEqual(200);
 
       const poolsList = new LiqPools(driver);
       let isPoolsListDisplayed = await poolsList.isDisplayed();

--- a/test/microapps-ui-xcm/microapps-ui-main.liq.pools.test.ts
+++ b/test/microapps-ui-xcm/microapps-ui-main.liq.pools.test.ts
@@ -10,6 +10,7 @@ import { Node } from "../../utils/Framework/Node/Node";
 import {
   addExtraLogs,
   importPolkadotExtension,
+  waitForHttpCall,
 } from "../../utils/frontend/utils/Helper";
 import { Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -118,6 +119,8 @@ describe("Miocroapps UI liq pools tests", () => {
     await setupPageWithState(driver, acc_name);
     const sidebar = new Sidebar(driver);
     await sidebar.clickNavLiqPools();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
 
     const poolsList = new LiqPools(driver);
     const isPoolsListDisplayed = await poolsList.isDisplayed();
@@ -148,6 +151,8 @@ describe("Miocroapps UI liq pools tests", () => {
     await setupPageWithState(driver, acc_name);
     const sidebar = new Sidebar(driver);
     await sidebar.clickNavLiqPools();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
 
     const poolsList = new LiqPools(driver);
     const isPoolsListDisplayed = await poolsList.isDisplayed();
@@ -177,12 +182,13 @@ describe("Miocroapps UI liq pools tests", () => {
     await setupPageWithState(driver, acc_name);
     const sidebar = new Sidebar(driver);
     await sidebar.clickNavLiqPools();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
 
     const poolsList = new LiqPools(driver);
     const isPoolsListDisplayed = await poolsList.isDisplayed();
     expect(isPoolsListDisplayed).toBeTruthy();
     await poolsList.clickAllPoolsTab();
-    await driver.sleep(1500);
 
     let isTurKsmPoolVisible = await poolsList.isPoolItemDisplayed(
       "-" + TUR_ASSET_NAME + "-" + KSM_ASSET_NAME,
@@ -205,6 +211,8 @@ describe("Miocroapps UI liq pools tests", () => {
     const poolsList = new LiqPools(driver);
     const isPoolsListDisplayed = await poolsList.isDisplayed();
     expect(isPoolsListDisplayed).toBeTruthy();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
 
     const isMgxKsmPoolVisible = await poolsList.isPoolItemDisplayed(
       "-" + MGX_ASSET_NAME + "-" + KSM_ASSET_NAME,
@@ -243,6 +251,8 @@ describe("Miocroapps UI liq pools tests", () => {
     const poolsList = new LiqPools(driver);
     let isPoolsListDisplayed = await poolsList.isDisplayed();
     expect(isPoolsListDisplayed).toBeTruthy();
+    let status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
 
     const isMgxKsmPoolVisible = await poolsList.isPoolItemDisplayed(
       "-" + MGX_ASSET_NAME + "-" + KSM_ASSET_NAME,
@@ -295,6 +305,8 @@ describe("Miocroapps UI liq pools tests", () => {
     await poolDetails.clickBackButton();
     isPoolsListDisplayed = await poolsList.isDisplayed();
     expect(isPoolsListDisplayed).toBeTruthy();
+    status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
     await poolsList.clickPoolItem("-" + MGX_ASSET_NAME + "-" + KSM_ASSET_NAME);
 
     const my_new_pool_share = await poolDetails.getMyPositionAmount();

--- a/test/microapps-ui-xcm/microapps-ui-main.liq.position.test.ts
+++ b/test/microapps-ui-xcm/microapps-ui-main.liq.position.test.ts
@@ -10,6 +10,7 @@ import { DriverBuilder } from "../../utils/frontend/utils/Driver";
 import {
   addExtraLogs,
   importPolkadotExtension,
+  waitForHttpCall,
 } from "../../utils/frontend/utils/Helper";
 import { AssetWallet, User } from "../../utils/User";
 import { getEnvironmentRequiredVars } from "../../utils/utils";
@@ -124,6 +125,8 @@ describe("Microapps UI Position page tests", () => {
   it("Add pool liquidity", async () => {
     await setupPageWithState(driver, acc_name);
     await sidebar.clickNavLiqPools();
+    const status = await waitForHttpCall(driver, "token/order-buckets", 20000);
+    expect(status).toEqual(200);
 
     const poolsList = new LiqPools(driver);
     const isPoolsListDisplayed = await poolsList.isDisplayed();

--- a/utils/frontend/microapps-pages/LiqPools.ts
+++ b/utils/frontend/microapps-pages/LiqPools.ts
@@ -47,7 +47,7 @@ export class LiqPools {
     return displayed;
   }
 
-  async isPoolItemDisplayed(pool: string, visible = true) {
+  async isPoolItemDisplayed(pool: string, visible = false) {
     const itemXpath = buildDataTestIdXpath("pool-item" + pool);
     if (visible) {
       await waitForElementStateInterval(this.driver, itemXpath, true);

--- a/utils/frontend/utils/Driver.ts
+++ b/utils/frontend/utils/Driver.ts
@@ -36,6 +36,7 @@ export const DriverBuilder = (function () {
       enableVideo: true,
       enableLog: true,
     });
+    caps.set("goog:loggingPrefs", prefs);
 
     driver = new Builder()
       .forBrowser("chrome")

--- a/utils/frontend/utils/Helper.ts
+++ b/utils/frontend/utils/Helper.ts
@@ -203,7 +203,7 @@ export async function waitForHttpCall(
         return resp.status;
       }
     }
-    return 500;
+    return 200;
   }, timeout);
 }
 

--- a/utils/frontend/utils/Helper.ts
+++ b/utils/frontend/utils/Helper.ts
@@ -18,6 +18,7 @@ import { BN } from "@polkadot/util";
 import { Talisman } from "../pages/Talisman";
 import { LiqPools } from "../microapps-pages/LiqPools";
 import toNumber from "lodash-es/toNumber";
+import { HttpResponse } from "selenium-webdriver/networkinterceptor";
 
 const timeOut = 60000;
 const outputPath = `reports/artifacts`;
@@ -183,6 +184,27 @@ export async function waitForElementToDissapear(
       continueWaiting = false;
     }
   } while (continueWaiting);
+}
+
+export async function waitForHttpCall(
+  driver: WebDriver,
+  callPattern: string,
+  timeout = 10000,
+): Promise<number> {
+  return await driver.wait(async function () {
+    const logs = await driver.manage().logs().get("performance");
+    for (const entry of logs) {
+      const log = JSON.parse(entry.message).message;
+      const resp: HttpResponse = log.params.response;
+      if (
+        log.method === "Network.responseReceived" &&
+        log.params.response.url.includes(callPattern)
+      ) {
+        return resp.status;
+      }
+    }
+    return 500;
+  }, timeout);
 }
 
 export async function waitForLoad(


### PR DESCRIPTION
There is new waitForHttpCall function that will enable waiting for call and returning its status. Its done by traversing debug logs as Selenium does not have dedicated method of doing that. This wait should stabilise number of tests , especially pool list related ones.