### PR TITLE
Nonexistent token withdraw test

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "start-prod": "node ./build/index.js",
     "build": "tsc --project tsconfig.json",
     "init-test": "rm nonce.db; rm sudo.lock;",
-    "test": "jest",
+    "test": "node --experimental-specifier-resolution=node --loader ts-node/esm --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test-run": "export JEST_HTML_REPORTERS_PUBLIC_PATH=reports/html-report-seq; rm nonce.db ; rm sudo.lock;  node --experimental-specifier-resolution=node --loader ts-node/esm --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit ",
     "test-parallel": "export JEST_HTML_REPORTERS_PUBLIC_PATH=reports/html-report-parallel;rm nonce.db ; rm sudo.lock; node --expose-gc --experimental-specifier-resolution=node --loader ts-node/esm --experimental-vm-modules node_modules/jest/bin/jest.js --verbose --ci --group=parallel --forceExit --workerIdleMemoryLimit=200MB --logHeapUsage",
     "test-parallel-3rdPartyRewards": "export JEST_HTML_REPORTERS_PUBLIC_PATH=reports/html-report-parallel;rm nonce.db ; rm sudo.lock; node --expose-gc --experimental-specifier-resolution=node --loader ts-node/esm --experimental-vm-modules node_modules/jest/bin/jest.js --verbose --ci --group=3rdPartyRewards --forceExit",

--- a/test/parallel/rolldown.withdraw.error.test.ts
+++ b/test/parallel/rolldown.withdraw.error.test.ts
@@ -1,3 +1,7 @@
+/*
+ *
+ * @group parallel
+ */
 import { getApi, initApi } from "../../utils/api";
 import { setupApi, setupUsers } from "../../utils/setup";
 import { User } from "../../utils/User";

--- a/test/parallel/rolldown.withdraw.error.test.ts
+++ b/test/parallel/rolldown.withdraw.error.test.ts
@@ -1,7 +1,6 @@
 import { getApi, initApi } from "../../utils/api";
 import { setupApi, setupUsers } from "../../utils/setup";
 import { User } from "../../utils/User";
-import { testLog } from "../../utils/Logger";
 import { expectExtrinsicFail } from "../../utils/utils";
 import { signTx } from "gasp-sdk";
 import { Assets } from "../../utils/Assets";
@@ -24,13 +23,10 @@ describe("Rolldown withdraw error", () => {
   });
 
   test("withdrawing token which does not exist should return correct error", async () => {
-    const api = getApi();
-    testLog
-      .getLog()
-      .info(
-        "--------------------------THE RESPONSE----------------------------",
-      );
     const nonExistingToken = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efa111";
+    const errorMsg = "TokenDoesNotExist";
+
+    const api = getApi();
 
     const withdrawTx = await Withdraw(
       user,
@@ -38,18 +34,9 @@ describe("Rolldown withdraw error", () => {
       nonExistingToken,
       "Ethereum",
     );
+
     const events = await signTx(api, withdrawTx, user.keyRingPair);
     const response = expectExtrinsicFail(events);
-    expect(response.data).toEqual("TokenDoesNotExist");
+    expect(response.data).toEqual(errorMsg);
   });
 });
-
-// function generateRandomAddress(): string {
-//   const randomBytes = crypto.getRandomValues(new Uint8Array(20));
-
-//   const address = Array.from(randomBytes)
-//     .map((byte) => byte.toString(16).padStart(2, "0"))
-//     .join("");
-
-//   return `0x${address}`;
-// }

--- a/test/parallel/rolldown.withdraw.error.test.ts
+++ b/test/parallel/rolldown.withdraw.error.test.ts
@@ -1,0 +1,158 @@
+import { Keyring } from "@polkadot/api";
+import { getApi, initApi } from "../../utils/api";
+import {
+  abi,
+  getAssetIdFromErc20,
+  getL2UpdatesStorage,
+  getPublicClient,
+  setupEthUser,
+} from "../../utils/rollup/ethUtils";
+import { getL1, L1Type } from "../../utils/rollup/l1s";
+import { setupApi, setupUsers } from "../../utils/setup";
+import { User } from "../../utils/User";
+import { testLog } from "../../utils/Logger";
+import { PrivateKeyAccount, Abi, createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+// import { Assets } from "../../utils/Assets";
+// import { Sudo } from "../../utils/sudo";
+import { waitForBalanceChange } from "../../utils/utils";
+import { signTx } from "gasp-sdk";
+
+let user: User;
+
+async function depositAndWait(depositor: User, l1: L1Type = "EthAnvil") {
+  const updatesBefore = await getL2UpdatesStorage(l1);
+  testLog.getLog().info(JSON.stringify(updatesBefore));
+  const acc: PrivateKeyAccount = privateKeyToAccount(
+    depositor.name as `0x${string}`,
+  );
+  const publicClient = getPublicClient(l1);
+  const { request } = await publicClient.simulateContract({
+    account: acc,
+    address: getL1(l1)?.contracts?.rollDown.address!,
+    abi: abi as Abi,
+    functionName: "deposit",
+    args: [getL1(l1)?.contracts.dummyErc20.address, BigInt(112233445566)],
+  });
+  const wc = createWalletClient({
+    account: acc,
+    chain: getL1(l1),
+    transport: http(),
+  });
+  await wc.writeContract(request);
+
+  const updatesAfter = await getL2UpdatesStorage(l1);
+  testLog.getLog().info(JSON.stringify(updatesAfter));
+
+  // eslint-disable-next-line no-console
+  console.log(updatesAfter);
+  // eslint-disable-next-line no-console
+  console.log(updatesBefore);
+  // TODO: verify that deposit is present in the pendingDeposits in l2update
+  //validate that the request got inserted.
+  // expect(
+  //   parseInt(JSON.parse(JSON.stringify(updatesAfter)).lastAcceptedRequestOnL1),
+  // ).toBeGreaterThan(
+  //   parseInt(JSON.parse(JSON.stringify(updatesBefore)).lastAcceptedRequestOnL1),
+  // );
+  testLog.getLog().info(depositor.keyRingPair.address);
+  const assetId = await getAssetIdFromErc20(
+    getL1(l1)?.contracts.dummyErc20.address!,
+    l1,
+  );
+  // Wait for the balance to change
+  return await waitForBalanceChange(depositor.keyRingPair.address, 40, assetId);
+}
+
+describe("Rolldown withdraw error", () => {
+  beforeEach(async () => {
+    try {
+      getApi();
+    } catch (e) {
+      await initApi();
+    }
+    await setupApi();
+    [user] = setupUsers();
+    const keyRing = new Keyring({ type: "ethereum" });
+    user = new User(keyRing);
+    const params = getL1("EthAnvil");
+    await setupEthUser(
+      user,
+      params?.contracts.dummyErc20.address!,
+      params?.contracts.rollDown.address!,
+      112233445566,
+    );
+  });
+
+  test("withdrawing token which does not exist should return correct error", async () => {
+    const api = getApi();
+    // eslint-disable-next-line no-console
+    console.log(
+      "--------------------------THE RESPONSE----------------------------",
+    );
+    // const randomAddress = generateRandomAddress();
+    // eslint-disable-next-line no-console
+    // console.log("random address: ", randomAddress);
+    const anyChange = await depositAndWait(user);
+    // Check that got updated.
+    expect(anyChange).toBeTruthy();
+    // const erc20Address = getL1("EthAnvil")?.contracts.dummyErc20.address!;
+    // await Sudo.batchAsSudoFinalized(Assets.mintNative(user));
+    const tx = getApi().tx.rolldown.withdraw(
+      "Ethereum",
+      user.keyRingPair.address,
+      "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efa111",
+      1122,
+    );
+    // const balanceBefore = await getBalance(
+    //   erc20Address,
+    //   user.keyRingPair.address,
+    //   "EthAnvil",
+    // );
+    // eslint-disable-next-line no-console
+    console.log(
+      "--------------------------THE RESPONSE----------------------------",
+    );
+    const res = await signTx(api, tx, user.keyRingPair);
+    // expectExtrinsicFail(res);
+    // eslint-disable-next-line no-console
+    console.log(
+      "--------------------------HERE IS THE RESPONSE----------------------------",
+    );
+    // eslint-disable-next-line no-console
+    console.dir(res);
+    // expect(res).toBeTruthy();
+
+    //     let balanceAfter = await getBalance(
+    //       erc20Address,
+    //       user.keyRingPair.address,
+    //       "EthAnvil",
+    //     );
+    //     while (
+    //       BigInt((balanceAfter as any).toString()) <=
+    //       BigInt((balanceBefore as any).toString())
+    //     ) {
+    //       await new Promise((resolve) => setTimeout(resolve, 5000));
+    //       balanceAfter = await getBalance(
+    //         erc20Address,
+    //         user.keyRingPair.address,
+    //         "EthAnvil",
+    //       );
+    //       testLog.getLog().info(balanceAfter);
+    //     }
+    //     const diff =
+    //       BigInt((balanceAfter as any).toString()) -
+    //       BigInt((balanceBefore as any).toString());
+    //     expect(diff).toBe(BigInt(1122));
+  });
+});
+
+// function generateRandomAddress(): string {
+//   const randomBytes = crypto.getRandomValues(new Uint8Array(20));
+
+//   const address = Array.from(randomBytes)
+//     .map((byte) => byte.toString(16).padStart(2, "0"))
+//     .join("");
+
+//   return `0x${address}`;
+// }

--- a/test/parallel/rolldown.withdraw.error.test.ts
+++ b/test/parallel/rolldown.withdraw.error.test.ts
@@ -1,68 +1,15 @@
-import { Keyring } from "@polkadot/api";
 import { getApi, initApi } from "../../utils/api";
-import {
-  abi,
-  getAssetIdFromErc20,
-  getL2UpdatesStorage,
-  getPublicClient,
-  setupEthUser,
-} from "../../utils/rollup/ethUtils";
-import { getL1, L1Type } from "../../utils/rollup/l1s";
 import { setupApi, setupUsers } from "../../utils/setup";
 import { User } from "../../utils/User";
 import { testLog } from "../../utils/Logger";
-import { PrivateKeyAccount, Abi, createWalletClient, http } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
-// import { Assets } from "../../utils/Assets";
-// import { Sudo } from "../../utils/sudo";
-import { waitForBalanceChange } from "../../utils/utils";
+import { expectExtrinsicFail } from "../../utils/utils";
 import { signTx } from "gasp-sdk";
+import { Assets } from "../../utils/Assets";
+import { Sudo } from "../../utils/sudo";
+import { Withdraw } from "../../utils/rolldown";
+import { BN_TWO } from "@polkadot/util";
 
 let user: User;
-
-async function depositAndWait(depositor: User, l1: L1Type = "EthAnvil") {
-  const updatesBefore = await getL2UpdatesStorage(l1);
-  testLog.getLog().info(JSON.stringify(updatesBefore));
-  const acc: PrivateKeyAccount = privateKeyToAccount(
-    depositor.name as `0x${string}`,
-  );
-  const publicClient = getPublicClient(l1);
-  const { request } = await publicClient.simulateContract({
-    account: acc,
-    address: getL1(l1)?.contracts?.rollDown.address!,
-    abi: abi as Abi,
-    functionName: "deposit",
-    args: [getL1(l1)?.contracts.dummyErc20.address, BigInt(112233445566)],
-  });
-  const wc = createWalletClient({
-    account: acc,
-    chain: getL1(l1),
-    transport: http(),
-  });
-  await wc.writeContract(request);
-
-  const updatesAfter = await getL2UpdatesStorage(l1);
-  testLog.getLog().info(JSON.stringify(updatesAfter));
-
-  // eslint-disable-next-line no-console
-  console.log(updatesAfter);
-  // eslint-disable-next-line no-console
-  console.log(updatesBefore);
-  // TODO: verify that deposit is present in the pendingDeposits in l2update
-  //validate that the request got inserted.
-  // expect(
-  //   parseInt(JSON.parse(JSON.stringify(updatesAfter)).lastAcceptedRequestOnL1),
-  // ).toBeGreaterThan(
-  //   parseInt(JSON.parse(JSON.stringify(updatesBefore)).lastAcceptedRequestOnL1),
-  // );
-  testLog.getLog().info(depositor.keyRingPair.address);
-  const assetId = await getAssetIdFromErc20(
-    getL1(l1)?.contracts.dummyErc20.address!,
-    l1,
-  );
-  // Wait for the balance to change
-  return await waitForBalanceChange(depositor.keyRingPair.address, 40, assetId);
-}
 
 describe("Rolldown withdraw error", () => {
   beforeEach(async () => {
@@ -73,77 +20,27 @@ describe("Rolldown withdraw error", () => {
     }
     await setupApi();
     [user] = setupUsers();
-    const keyRing = new Keyring({ type: "ethereum" });
-    user = new User(keyRing);
-    const params = getL1("EthAnvil");
-    await setupEthUser(
-      user,
-      params?.contracts.dummyErc20.address!,
-      params?.contracts.rollDown.address!,
-      112233445566,
-    );
+    await Sudo.batchAsSudoFinalized(Assets.mintNative(user));
   });
 
   test("withdrawing token which does not exist should return correct error", async () => {
     const api = getApi();
-    // eslint-disable-next-line no-console
-    console.log(
-      "--------------------------THE RESPONSE----------------------------",
-    );
-    // const randomAddress = generateRandomAddress();
-    // eslint-disable-next-line no-console
-    // console.log("random address: ", randomAddress);
-    const anyChange = await depositAndWait(user);
-    // Check that got updated.
-    expect(anyChange).toBeTruthy();
-    // const erc20Address = getL1("EthAnvil")?.contracts.dummyErc20.address!;
-    // await Sudo.batchAsSudoFinalized(Assets.mintNative(user));
-    const tx = getApi().tx.rolldown.withdraw(
-      "Ethereum",
-      user.keyRingPair.address,
-      "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efa111",
-      1122,
-    );
-    // const balanceBefore = await getBalance(
-    //   erc20Address,
-    //   user.keyRingPair.address,
-    //   "EthAnvil",
-    // );
-    // eslint-disable-next-line no-console
-    console.log(
-      "--------------------------THE RESPONSE----------------------------",
-    );
-    const res = await signTx(api, tx, user.keyRingPair);
-    // expectExtrinsicFail(res);
-    // eslint-disable-next-line no-console
-    console.log(
-      "--------------------------HERE IS THE RESPONSE----------------------------",
-    );
-    // eslint-disable-next-line no-console
-    console.dir(res);
-    // expect(res).toBeTruthy();
+    testLog
+      .getLog()
+      .info(
+        "--------------------------THE RESPONSE----------------------------",
+      );
+    const nonExistingToken = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efa111";
 
-    //     let balanceAfter = await getBalance(
-    //       erc20Address,
-    //       user.keyRingPair.address,
-    //       "EthAnvil",
-    //     );
-    //     while (
-    //       BigInt((balanceAfter as any).toString()) <=
-    //       BigInt((balanceBefore as any).toString())
-    //     ) {
-    //       await new Promise((resolve) => setTimeout(resolve, 5000));
-    //       balanceAfter = await getBalance(
-    //         erc20Address,
-    //         user.keyRingPair.address,
-    //         "EthAnvil",
-    //       );
-    //       testLog.getLog().info(balanceAfter);
-    //     }
-    //     const diff =
-    //       BigInt((balanceAfter as any).toString()) -
-    //       BigInt((balanceBefore as any).toString());
-    //     expect(diff).toBe(BigInt(1122));
+    const withdrawTx = await Withdraw(
+      user,
+      BN_TWO,
+      nonExistingToken,
+      "Ethereum",
+    );
+    const events = await signTx(api, withdrawTx, user.keyRingPair);
+    const response = expectExtrinsicFail(events);
+    expect(response.data).toEqual("TokenDoesNotExist");
   });
 });
 

--- a/test/rollup/rolldown.test.skip.ts
+++ b/test/rollup/rolldown.test.skip.ts
@@ -8,7 +8,7 @@ import { EthUser } from "../../utils/EthUser";
 import {
   getLastProcessedRequestNumber,
   rolldownDeposit,
-  rolldownWithdraw,
+  Withdraw,
 } from "../../utils/rolldown";
 import { signTx } from "gasp-sdk";
 import { signTxMetamask } from "../../utils/metamask";
@@ -73,7 +73,7 @@ describe("Tests with rolldown functions:", () => {
     await waitForNBlocks(4);
 
     await signTxMetamask(
-      await rolldownWithdraw(testEthUser, 100),
+      await Withdraw(testEthUser, 100),
       testEthUser.ethAddress,
       testEthUser.privateKey,
     );

--- a/test/sequential/maintenance-pallet.api.rolldown.test.ts
+++ b/test/sequential/maintenance-pallet.api.rolldown.test.ts
@@ -31,7 +31,7 @@ import { User } from "../../utils/User";
 import { L2Update, Rolldown } from "../../utils/rollDown/Rolldown";
 import { SequencerStaking } from "../../utils/rollDown/SequencerStaking";
 import { SudoDB } from "../../utils/SudoDB";
-import { RollDown, rolldownWithdraw } from "../../utils/rolldown";
+import { RollDown, Withdraw } from "../../utils/rolldown";
 import { testLog } from "../../utils/Logger";
 import {
   checkMaintenanceStatus,
@@ -155,7 +155,7 @@ describe.each(["mm", "upgradabilityMm"])(
             sequencer,
           ],
           withdraw: [
-            await rolldownWithdraw(
+            await Withdraw(
               users[0],
               BN_HUNDRED,
               tokenAddress.toString(),

--- a/utils/rolldown.ts
+++ b/utils/rolldown.ts
@@ -40,7 +40,7 @@ export async function getLastProcessedRequestNumber() {
   return +value;
 }
 
-export async function rolldownWithdraw(
+export async function Withdraw(
   EthUser: EthUser | User,
   amountValue: BN | number,
   tokenAddress: string = "",
@@ -77,7 +77,7 @@ export class RollDown {
     tokenAddress: string = "",
     chainName: ChainName = "Ethereum",
   ) {
-    return rolldownWithdraw(EthUser, amountValue, tokenAddress, chainName);
+    return Withdraw(EthUser, amountValue, tokenAddress, chainName);
   }
   static async deposit(
     requestNumber: number,

--- a/utils/rolldown.ts
+++ b/utils/rolldown.ts
@@ -71,19 +71,4 @@ export class RollDown {
     }
     return sdkApi.tx.rolldown.cancelRequestsFromL1(chain, requestNumber);
   }
-  static async withdraw(
-    EthUser: EthUser | User,
-    amountValue: BN | number,
-    tokenAddress: string = "",
-    chainName: ChainName = "Ethereum",
-  ) {
-    return Withdraw(EthUser, amountValue, tokenAddress, chainName);
-  }
-  static async deposit(
-    requestNumber: number,
-    ethAddress: string,
-    amountValue: number,
-  ) {
-    return rolldownDeposit(requestNumber, ethAddress, amountValue);
-  }
 }

--- a/utils/setupsOnTheGo.ts
+++ b/utils/setupsOnTheGo.ts
@@ -50,7 +50,7 @@ import { MPL } from "./MPL";
 import {
   getLastProcessedRequestNumber,
   rolldownDeposit,
-  rolldownWithdraw,
+  Withdraw,
 } from "./rolldown";
 import { EthUser } from "./EthUser";
 import { signTxMetamask } from "./metamask";
@@ -1793,7 +1793,7 @@ export async function withdrawToL1(ethPrivateKey: string, amountValue: number) {
   const testEthUser = new EthUser(keyring, ethPrivateKey);
 
   await signTxMetamask(
-    await rolldownWithdraw(testEthUser, 100),
+    await Withdraw(testEthUser, 100),
     testEthUser.ethAddress,
     testEthUser.privateKey,
   );


### PR DESCRIPTION
When withdrawing a token that does not exist, it returned a `MathOverflow`, now it returns correct error `TokenDoesNotExist`.

Added command for running single test via `yarn test <nameOfTheTest.test.ts>`
Also a little polishing, 2 unused and recurrent methods were removed. 

Jira ticket: https://mangatafinance.atlassian.net/browse/MGX-1406